### PR TITLE
fix: Update message query selector

### DIFF
--- a/src/gccg.js
+++ b/src/gccg.js
@@ -41,7 +41,7 @@ const getCommitDataFromUrl = async (url) => {
     commits.push({
       url: url,
       author: node.querySelector("a.avatar img").alt.slice(1), // returns username without '@'
-      msg: node.querySelector(".commit-message code a").title, // returns the entire commit message (every line)
+      msg: node.querySelector("code a").title, // returns the entire commit message (every line)
     })
   });
 


### PR DESCRIPTION
Github changed their DOM structure to no longer include a `.commit-message` class.